### PR TITLE
fix: save config for the first time on windows

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
@@ -47,7 +46,8 @@ func Get() Config {
 
 func Save(config Config) {
 	// Make sure the config directory exists
-	err := os.MkdirAll(path.Dir(configfile()), 0750)
+	configdir, _ := filepath.Split(configfile())
+	err := os.MkdirAll(configdir, 0750)
 	if err != nil {
 		fmt.Println("Unable to create config directory:", err)
 		os.Exit(1)


### PR DESCRIPTION
I found out that `path.Dir(configfile())` returns `.` instead of actual path. 

My "discovery": 
![Zrzut ekranu 2022-07-20 222454](https://user-images.githubusercontent.com/17083034/180076203-ceda1799-f5f3-404b-b366-5daa6d349725.png)

Fixes #3